### PR TITLE
Change RANKING_URL to the current ranking

### DIFF
--- a/hltv_data/client.py
+++ b/hltv_data/client.py
@@ -9,7 +9,7 @@ from selenium.webdriver.support import expected_conditions as EC
 BASE_URL = "https://www.hltv.org"
 MATCHES_URL = f"{BASE_URL}/matches"
 RESULTS_URL = f"{BASE_URL}/results"
-RANKING_URL = f"{BASE_URL}/ranking/teams/2024/march/5"
+RANKING_URL = f"{BASE_URL}/ranking/teams"
 
 
 class HLTVClient:


### PR DESCRIPTION
Without this change, the ranking that is pulled is always the one from March 5 2024. With this change, it will use the .../ranking/teams URL that automatically resolves into the current ranking.

Potential alternatives:
- Add a date input to `get_ranking()` to allow the user to specify which ranking to pull (-> the ranking most recently before / on the given input date). The default would be to pull the current one.
- Move the URL variables into the class as attributes, such that a user could override, either within an instance of the class or by making a child class.

Edit: I now see this implements the request in issue #5 